### PR TITLE
SCS-963 settings updates

### DIFF
--- a/css/sitka-insights-admin.css
+++ b/css/sitka-insights-admin.css
@@ -12,11 +12,15 @@
 }
 .sitka-field input[type=text] {
   width: 100%;
+  max-width: 25em;
 }
 textarea.sitka-shortcode-text {
+  height: 2em;
+  width: 16ch;
+  padding-top: 2px;
+  width: 16ch;
   color: black;
   font-weight: 700;
   border: none;
-  height: 2em;
-  width: 16ch;
+  resize: none;
 }

--- a/css/sitka-insights-admin.css
+++ b/css/sitka-insights-admin.css
@@ -10,6 +10,9 @@
 .sitka-field__input {
   width: 80%;
 }
+.sitka-field__env-option {
+  margin-bottom: 0.5em;
+}
 .sitka-field input[type=text] {
   width: 100%;
   max-width: 25em;

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -51,8 +51,21 @@ add_filter('sitka/api/client', function() {
   return $client ?: new Client([
     'key'        => get_option('sitka_api_key'),
     'collection' => get_option('sitka_collection_id'),
-    'baseUri'    => get_option('sitka_base_uri'),
+    'baseUri'    => apply_filters('sitka/api/base_uri', ''),
   ]);
+});
+
+add_filter('sitka/api/base_uri', function() {
+  $env  = get_option('sitka_environment');
+  $uris = [
+    'production' => 'https://prd.search-api-gateway.aws.gearlabnw.net',
+    'staging'    => 'https://stg.search-api-gateway.aws.gearlabnw.net',
+  ];
+
+  $uri  = $uris[$env] ?? $uris['production'];
+  debug($uri);
+
+  return $uri;
 });
 
 
@@ -66,7 +79,7 @@ add_action('admin_menu', function() {
     'option_keys' => [
       'sitka_api_key',
       'sitka_collection_id',
-      'sitka_base_uri',
+      'sitka_environment',
       'sitka_search_enabled',
       'sitka_search_redirect',
     ],

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -78,6 +78,7 @@ add_action('admin_menu', function() {
   $page = AdminPage::add_options_page([
     'option_keys' => [
       'sitka_api_key',
+      'sitka_site_id',
       'sitka_collection_id',
       'sitka_environment',
       'sitka_search_enabled',

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -7,6 +7,7 @@
  * Author: SiteCrafting, Inc. <hello@sitecrafting.com>
  * Author URI: https://www.sitecrafting.com/
  * Version: 2.0.0
+ * Requires PHP: 7.1
  */
 
 // no script kiddiez

--- a/views/settings-meta.php
+++ b/views/settings-meta.php
@@ -1,4 +1,5 @@
-<form name="sitka-insights-settings" method="post">
+<form name="sitka-insights-settings" method="post" autofill="false">
+  <h3>Search Settings</h3>
   <div class="sitka-field sitka-field--flex">
     <div class="sitka-field__label">
       <label for="sitka_api_key"><b>API Key</b></label>
@@ -10,29 +11,35 @@
 
   <div class="sitka-field sitka-field--flex">
     <div class="sitka-field__label">
-      <label for="sitka_collection_id"><b>Collection ID</b></label>
+      <label for="sitka_collection_id"><b>Engine ID</b></label>
     </div>
     <div class="sitka-field__input">
       <input type="text" id="sitka_collection_id" name="sitka_collection_id" value="<?= $data['sitka_collection_id'] ?>">
     </div>
   </div>
 
-  <?php // TODO: configure a radio toggle between Staging/Live environments ?>
   <div class="sitka-field sitka-field--flex">
     <div class="sitka-field__label">
-      <label for="sitka_base_uri"><b>Base URI</b></label>
+      <label><b>Environment</b></label>
     </div>
     <div class="sitka-field__input">
-      <input type="text" id="sitka_base_uri" name="sitka_base_uri" value="<?= $data['sitka_base_uri'] ?>">
+      <div>
+        <input type="radio" id="env-prd" name="sitka_environment" value="production" <?= $data['sitka_environment'] === 'production' ? 'checked' : '' ?>>
+        <label for="env-prd">Production</label>
+      </div>
+      <div>
+        <input type="radio" id="env-stg" name="sitka_environment" value="staging" <?= $data['sitka_environment'] === 'staging' ? 'checked' : '' ?>>
+        <label for="env-stg">Staging</label>
+      </div>
     </div>
   </div>
 
   <div class="sitka-field">
-    <h3>Override WP Search</h3>
-    <p>Use this shortcode on any page:</p>
-    <textarea class="sitka-shortcode-text" disabled>[sitka_search]</textarea>
+    <p>Please insert this shortcode on the page where you would like search results to appear.</p>
+    <textarea id="sitka-shortcode" class="sitka-shortcode-text" disabled>[sitka_search]</textarea>
     <button type="button" class="button button-secondary sitka-shortcode-copy">Copy to clipboard</button>
-    <p>Unless you have custom-built an integration, for your theme's normal search form to work, you must enable one of the following options:</p>
+    <br>
+    <br>
     <p>
       <input
         type="radio"
@@ -52,7 +59,7 @@
         value="<?= SITKA_OVERRIDE_METHOD_SHORTCODE ?>"
         <?= $searchRedirectEnabled ? 'checked' : '' ?>
       />
-      <label for="sitka-search-shortcode"><b>Redirect searches to a specific page (Recommended)</b></label>
+      <label for="sitka-search-shortcode"><b>Enable Sitka Search and redirect searches to the page where you added the shortcode above. (Recommended)</b></label>
     </p>
     <p class="sitka-redirect-url-field" <?= $searchRedirectEnabled ? '' : 'style="display:none"' ?>>
       <label for="sitka-search-page-redirect"><b>Redirect searches to:</b></label>
@@ -63,7 +70,6 @@
         value="<?= $data['sitka_search_redirect'] ?>"
         placeholder="/search"
       />
-      <em>Do not include "?" or else redirects may not work properly. The page you specify here must contain the shortcode above.</em>
     </p>
   </div>
   <script>

--- a/views/settings-meta.php
+++ b/views/settings-meta.php
@@ -1,4 +1,14 @@
 <form name="sitka-insights-settings" method="post" autofill="false">
+  <h3>General Settings</h3>
+  <div class="sitka-field sitka-field--flex">
+    <div class="sitka-field__label">
+      <label for="sitka_site_id"><b>Site ID</b></label>
+    </div>
+    <div class="sitka-field__input">
+      <input type="text" id="sitka_site_id" name="sitka_site_id" value="<?= $data['sitka_site_id'] ?>">
+    </div>
+  </div>
+
   <h3>Search Settings</h3>
   <div class="sitka-field sitka-field--flex">
     <div class="sitka-field__label">

--- a/views/settings-meta.php
+++ b/views/settings-meta.php
@@ -33,11 +33,11 @@
       <label><b>Environment</b></label>
     </div>
     <div class="sitka-field__input">
-      <div>
+      <div class="sitka-field__env-option">
         <input type="radio" id="env-prd" name="sitka_environment" value="production" <?= $data['sitka_environment'] === 'production' ? 'checked' : '' ?>>
         <label for="env-prd">Production</label>
       </div>
-      <div>
+      <div class="sitka-field__env-option">
         <input type="radio" id="env-stg" name="sitka_environment" value="staging" <?= $data['sitka_environment'] === 'staging' ? 'checked' : '' ?>>
         <label for="env-stg">Staging</label>
       </div>

--- a/views/settings-meta.php
+++ b/views/settings-meta.php
@@ -6,6 +6,7 @@
     </div>
     <div class="sitka-field__input">
       <input type="text" id="sitka_site_id" name="sitka_site_id" value="<?= $data['sitka_site_id'] ?>">
+      <p><span class="dashicons dashicons-editor-help"></span>Not sure where to find your Site ID? <a href="https://dashboard.sitkainsights.com/embed/install">Get step-by-step instructions</a>.</p>
     </div>
   </div>
 


### PR DESCRIPTION
Implement the bulk of https://sitecrafting.atlassian.net/browse/SCS-963

This builds on PR #2.

## High Level AC

- Search settings - User can input API Key, Engine (Collection) ID, and also toggle between staging or production
- Shortcode - User can easily copy/paste the shortcode for setting up search - [sitka_search] 
- Overrides - User can select between “Use WordPress search results page” which will not override WP search or Enable Sitka Search. 

**Search settings:**

* API Key input 
* Engine ID input
* Radio toggle for environment with options for production and staging

**Shortcode**

Please insert this shortcode on the page where you would like search results to appear

Shortcode `[sitka_search]`

**Radio buttons**

* Use WordPress search results page
* Enable Sitka Search & redirect searches to the page where you installed the short code above. (Recommended)
* Input box with label "Redirect searches to:" with placeholder text for /search_results

**Save button**

Wireframe: https://invis.io/WBXZV0K7KTX#/424490733_Plugin