### PR TITLE
Curated results

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "php": ">=7.3",
     "composer/installers": "~1.0",
-    "sitecrafting/gearlab-tools-php": "dev-curated-results"
+    "sitecrafting/gearlab-tools-php": "^3.0"
   },
   "license": "MIT",
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "php": ">=7.3",
     "composer/installers": "~1.0",
-    "sitecrafting/gearlab-tools-php": "v2.0.0-rc.03"
+    "sitecrafting/gearlab-tools-php": "dev-curated-results"
   },
   "license": "MIT",
   "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53242bbeb18e7477cb588970d25e8d5e",
+    "content-hash": "70105110e6602dd52c147aa13407c99d",
     "packages": [
         {
             "name": "composer/installers",
@@ -608,16 +608,16 @@
         },
         {
             "name": "sitecrafting/gearlab-tools-php",
-            "version": "dev-curated-results",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sitecrafting/gearlab-tools-php.git",
-                "reference": "282c6f29419cba8583214c01ff843b77898d9cf7"
+                "reference": "07dcc6d8180058831b3d1807c8f5ce6198629a2a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sitecrafting/gearlab-tools-php/zipball/282c6f29419cba8583214c01ff843b77898d9cf7",
-                "reference": "282c6f29419cba8583214c01ff843b77898d9cf7",
+                "url": "https://api.github.com/repos/sitecrafting/gearlab-tools-php/zipball/07dcc6d8180058831b3d1807c8f5ce6198629a2a",
+                "reference": "07dcc6d8180058831b3d1807c8f5ce6198629a2a",
                 "shasum": ""
             },
             "require": {
@@ -657,9 +657,9 @@
             ],
             "support": {
                 "issues": "https://github.com/sitecrafting/gearlab-tools-php/issues",
-                "source": "https://github.com/sitecrafting/gearlab-tools-php/tree/curated-results"
+                "source": "https://github.com/sitecrafting/gearlab-tools-php/tree/v3.0.0"
             },
-            "time": "2024-10-23T14:00:52+00:00"
+            "time": "2024-10-29T22:08:25+00:00"
         },
         {
             "name": "symfony/console",
@@ -2979,9 +2979,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "sitecrafting/gearlab-tools-php": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "368b5dc9ca4c3473643dfb92fce946ab",
+    "content-hash": "53242bbeb18e7477cb588970d25e8d5e",
     "packages": [
         {
             "name": "composer/installers",
@@ -608,16 +608,16 @@
         },
         {
             "name": "sitecrafting/gearlab-tools-php",
-            "version": "v2.0.0-rc.03",
+            "version": "dev-curated-results",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sitecrafting/gearlab-tools-php.git",
-                "reference": "eaa4419e28bffdd82bfada5ba9ef5ab8c80bd7df"
+                "reference": "282c6f29419cba8583214c01ff843b77898d9cf7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sitecrafting/gearlab-tools-php/zipball/eaa4419e28bffdd82bfada5ba9ef5ab8c80bd7df",
-                "reference": "eaa4419e28bffdd82bfada5ba9ef5ab8c80bd7df",
+                "url": "https://api.github.com/repos/sitecrafting/gearlab-tools-php/zipball/282c6f29419cba8583214c01ff843b77898d9cf7",
+                "reference": "282c6f29419cba8583214c01ff843b77898d9cf7",
                 "shasum": ""
             },
             "require": {
@@ -657,9 +657,9 @@
             ],
             "support": {
                 "issues": "https://github.com/sitecrafting/gearlab-tools-php/issues",
-                "source": "https://github.com/sitecrafting/gearlab-tools-php/tree/v2.0.0-rc.03"
+                "source": "https://github.com/sitecrafting/gearlab-tools-php/tree/curated-results"
             },
-            "time": "2024-10-11T22:20:31+00:00"
+            "time": "2024-10-23T14:00:52+00:00"
         },
         {
             "name": "symfony/console",
@@ -2980,7 +2980,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "sitecrafting/gearlab-tools-php": 5
+        "sitecrafting/gearlab-tools-php": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/css/sitka-insights-search.css
+++ b/css/sitka-insights-search.css
@@ -27,14 +27,9 @@ padding: 20px;
 }
 .curated-result-headline {
   margin-bottom: 0;
-  order: 1;
 }
-.curated-result-text {
-  order: 3;
-}
-.curated-result-link {
-  order: 2;
-}
+.curated-result-text {}
+.curated-result-link {}
 .curated-result-button {
   display: inline-block;
   align-items: center;
@@ -48,7 +43,6 @@ padding: 20px;
   color: #000;
   background: #00aeef;
   -webkit-appearance: none;
-  order: 4;
 }
 
 .curated-result-button:hover {

--- a/css/sitka-insights-search.css
+++ b/css/sitka-insights-search.css
@@ -4,6 +4,57 @@
   padding-bottom: 30px;
   border-bottom: 1px solid #d8d8d8;
 }
+.curated-results {
+background-color: #f6f6f6;
+
+display: flex;
+flex-direction: column;
+gap: 20px;
+
+padding: 20px;
+}
+.sitka-curated-results-section-headline {
+  margin-bottom: 0;
+}
+.sitka-curated-result {
+  padding: 20px;
+  border: 1px solid #d8d8d8;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+.curated-result-headline {
+  margin-bottom: 0;
+  order: 1;
+}
+.curated-result-text {
+  order: 3;
+}
+.curated-result-link {
+  order: 2;
+}
+.curated-result-button {
+  display: inline-block;
+  align-items: center;
+  column-gap: 12px;
+  padding: 20px 28px;
+  cursor: pointer;
+  border: 0;
+
+  text-decoration: none;
+  
+  color: #000;
+  background: #00aeef;
+  -webkit-appearance: none;
+  order: 4;
+}
+
+.curated-result-button:hover {
+  color: #000;
+  text-decoration: none;
+}
 .sitka-search-card__label{
   text-transform: uppercase;
   margin: 0 0 5px 0;

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -97,6 +97,7 @@ add_action('admin_menu', function() {
       'sitka_search_enabled',
       'sitka_search_redirect',
       'sitka_search_instead_enabled',
+      'sitka_search_curated_results_enabled',
     ],
   ]);
   // Process any user updates

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -6,7 +6,7 @@
  * Plugin URI: https://www.sitkainsights.com
  * Author: SiteCrafting, Inc. <hello@sitecrafting.com>
  * Author URI: https://www.sitecrafting.com/
- * Version: 2.3.3
+ * Version: 3.0.0
  * Requires PHP: 7.1
  */
 

--- a/src/Paginated.php
+++ b/src/Paginated.php
@@ -11,6 +11,9 @@
 namespace Sitka\Plugin;
 
 trait Paginated {
+
+  protected $pagination;
+
   public function set_pagination(array $pagination) {
     $this->pagination = $pagination;
   }

--- a/views/frontend/curated-result-field-templates/curated-result-field-template-button.php
+++ b/views/frontend/curated-result-field-templates/curated-result-field-template-button.php
@@ -6,6 +6,6 @@ $field = $data['curated_result_field'] ?? [];
 
 <?php foreach ($field['value'] as $field_link) : ?>
   
-  <a href="<?= $field_link['url'] ?>" target="<?= (isset($field_link['new_window']) && $field_link['new_window'] ? '_blank' : '_self') ?>" class="curated-result-button btn"><?= $field_link['link_text'] ?></a>
+  <a href="<?= $field_link['url'] ?>" target="<?= (isset($field_link['new_window']) && $field_link['new_window'] ? '_blank' : '_self') ?>" class="curated-result-<?= $field['type'] ?>"><?= $field_link['link_text'] ?></a>
 
 <?php endforeach; ?>

--- a/views/frontend/curated-result-field-templates/curated-result-field-template-button.php
+++ b/views/frontend/curated-result-field-templates/curated-result-field-template-button.php
@@ -1,0 +1,11 @@
+<?php
+
+$field = $data['curated_result_field'] ?? [];
+
+?>
+
+<?php foreach ($field['value'] as $field_link) : ?>
+  
+  <a href="<?= $field_link['url'] ?>" target="<?= (isset($field_link['new_window']) && $field_link['new_window'] ? '_blank' : '_self') ?>" class="curated-result-button btn"><?= $field_link['link_text'] ?></a>
+
+<?php endforeach; ?>

--- a/views/frontend/curated-result-field-templates/curated-result-field-template-button.php
+++ b/views/frontend/curated-result-field-templates/curated-result-field-template-button.php
@@ -6,6 +6,12 @@ $field = $data['curated_result_field'] ?? [];
 
 <?php foreach ($field['value'] as $field_link) : ?>
   
-  <a href="<?= $field_link['url'] ?>" target="<?= (isset($field_link['new_window']) && $field_link['new_window'] ? '_blank' : '_self') ?>" class="curated-result-<?= $field['type'] ?>"><?= $field_link['link_text'] ?></a>
+  <?php $render = true; ?>
+  <?php if ( ($field_link['link_text'] ?? false) === false || empty($field_link['link_text'])) : $render = false; endif; ?>
+  <?php if ( ($field_link['url'] ?? false) === false || empty($field_link['url'])) : $render = false; endif; ?>
+
+  <?php if ($render) : ?>
+    <a href="<?= $field_link['url'] ?>" target="<?= (isset($field_link['new_window']) && $field_link['new_window'] ? '_blank' : '_self') ?>" class="curated-result-<?= $field['type'] ?>"><?= $field_link['link_text'] ?></a>
+  <?php endif; ?>
 
 <?php endforeach; ?>

--- a/views/frontend/curated-result-field-templates/curated-result-field-template-headline.php
+++ b/views/frontend/curated-result-field-templates/curated-result-field-template-headline.php
@@ -1,0 +1,11 @@
+<?php
+
+$field = $data['curated_result_field'] ?? [];
+
+?>
+
+<?php foreach ($field['value'] as $field_link) : ?>
+  
+  <h3 class="curated-result-headline"><?= $field_link['headline'] ?></h3>
+
+<?php endforeach; ?>

--- a/views/frontend/curated-result-field-templates/curated-result-field-template-headline.php
+++ b/views/frontend/curated-result-field-templates/curated-result-field-template-headline.php
@@ -6,6 +6,8 @@ $field = $data['curated_result_field'] ?? [];
 
 <?php foreach ($field['value'] as $field_link) : ?>
   
-  <h3 class="curated-result-<?= $field['type'] ?>"><?= $field_link['headline'] ?></h3>
+  <?php if ($field_value['headline'] ?? false && !empty($field_value['headline'])) : ?>
+    <h3 class="curated-result-<?= $field['type'] ?>"><?= $field_link['headline'] ?></h3>
+  <?php endif; ?>
 
 <?php endforeach; ?>

--- a/views/frontend/curated-result-field-templates/curated-result-field-template-headline.php
+++ b/views/frontend/curated-result-field-templates/curated-result-field-template-headline.php
@@ -6,6 +6,6 @@ $field = $data['curated_result_field'] ?? [];
 
 <?php foreach ($field['value'] as $field_link) : ?>
   
-  <h3 class="curated-result-headline"><?= $field_link['headline'] ?></h3>
+  <h3 class="curated-result-<?= $field['type'] ?>"><?= $field_link['headline'] ?></h3>
 
 <?php endforeach; ?>

--- a/views/frontend/curated-result-field-templates/curated-result-field-template-headline.php
+++ b/views/frontend/curated-result-field-templates/curated-result-field-template-headline.php
@@ -4,10 +4,10 @@ $field = $data['curated_result_field'] ?? [];
 
 ?>
 
-<?php foreach ($field['value'] as $field_link) : ?>
+<?php foreach ($field['value'] as $field_value) : ?>
   
   <?php if ($field_value['headline'] ?? false && !empty($field_value['headline'])) : ?>
-    <h3 class="curated-result-<?= $field['type'] ?>"><?= $field_link['headline'] ?></h3>
+    <h3 class="curated-result-<?= $field['type'] ?>"><?= $field_value['headline'] ?></h3>
   <?php endif; ?>
 
 <?php endforeach; ?>

--- a/views/frontend/curated-result-field-templates/curated-result-field-template-link.php
+++ b/views/frontend/curated-result-field-templates/curated-result-field-template-link.php
@@ -1,0 +1,11 @@
+<?php
+
+$field = $data['curated_result_field'] ?? [];
+
+?>
+
+<?php foreach ($field['value'] as $field_link) : ?>
+
+  <a href="<?= $field_link['url'] ?>" target="<?= ($field_link['new_window'] ? '_blank' : '_self') ?>" class="curated-result-link"><?= $field_link['link_text'] ?></a>
+
+<?php endforeach; ?>

--- a/views/frontend/curated-result-field-templates/curated-result-field-template-link.php
+++ b/views/frontend/curated-result-field-templates/curated-result-field-template-link.php
@@ -6,6 +6,6 @@ $field = $data['curated_result_field'] ?? [];
 
 <?php foreach ($field['value'] as $field_link) : ?>
 
-  <a href="<?= $field_link['url'] ?>" target="<?= ($field_link['new_window'] ? '_blank' : '_self') ?>" class="curated-result-link"><?= $field_link['link_text'] ?></a>
+  <a href="<?= $field_link['url'] ?>" target="<?= ($field_link['new_window'] ? '_blank' : '_self') ?>" class="curated-result-<?= $field['type'] ?>"><?= $field_link['link_text'] ?></a>
 
 <?php endforeach; ?>

--- a/views/frontend/curated-result-field-templates/curated-result-field-template-link.php
+++ b/views/frontend/curated-result-field-templates/curated-result-field-template-link.php
@@ -6,6 +6,12 @@ $field = $data['curated_result_field'] ?? [];
 
 <?php foreach ($field['value'] as $field_link) : ?>
 
-  <a href="<?= $field_link['url'] ?>" target="<?= ($field_link['new_window'] ? '_blank' : '_self') ?>" class="curated-result-<?= $field['type'] ?>"><?= $field_link['link_text'] ?></a>
+  <?php $render = true; ?>
+  <?php if ( ($field_link['link_text'] ?? false) === false || empty($field_link['link_text'])) : $render = false; endif; ?>
+  <?php if ( ($field_link['url'] ?? false) === false || empty($field_link['url'])) : $render = false; endif; ?>
+  
+  <?php if ($render) : ?>
+    <a href="<?= $field_link['url'] ?>" target="<?= ($field_link['new_window'] ? '_blank' : '_self') ?>" class="curated-result-<?= $field['type'] ?>"><?= $field_link['link_text'] ?></a>
+  <?php endif; ?>
 
 <?php endforeach; ?>

--- a/views/frontend/curated-result-field-templates/curated-result-field-template-text.php
+++ b/views/frontend/curated-result-field-templates/curated-result-field-template-text.php
@@ -1,11 +1,12 @@
 <?php
 
 $field = $data['curated_result_field'] ?? [];
-
 ?>
 
-<?php foreach ($field['value'] as $field_link) : ?>
+<?php foreach ($field['value'] as $field_value) : ?>
   
-  <div class="curated-result-<?= $field['type'] ?>"><?= $field_link['text'] ?></div>
+  <?php if ($field_value['text'] ?? false && !empty($field_value['text'])) : ?>
+    <div class="curated-result-<?= $field['type'] ?>"><?= $field_value['text'] ?></div>
+  <?php endif; ?>
 
 <?php endforeach; ?>

--- a/views/frontend/curated-result-field-templates/curated-result-field-template-text.php
+++ b/views/frontend/curated-result-field-templates/curated-result-field-template-text.php
@@ -6,6 +6,6 @@ $field = $data['curated_result_field'] ?? [];
 
 <?php foreach ($field['value'] as $field_link) : ?>
   
-  <div class="curated-result-text"><?= $field_link['text'] ?></div>
+  <div class="curated-result-<?= $field['type'] ?>"><?= $field_link['text'] ?></div>
 
 <?php endforeach; ?>

--- a/views/frontend/curated-result-field-templates/curated-result-field-template-text.php
+++ b/views/frontend/curated-result-field-templates/curated-result-field-template-text.php
@@ -1,0 +1,11 @@
+<?php
+
+$field = $data['curated_result_field'] ?? [];
+
+?>
+
+<?php foreach ($field['value'] as $field_link) : ?>
+  
+  <div class="curated-result-text"><?= $field_link['text'] ?></div>
+
+<?php endforeach; ?>

--- a/views/frontend/curated-result-templates/curated-result-template-quick_links.php
+++ b/views/frontend/curated-result-templates/curated-result-template-quick_links.php
@@ -1,0 +1,13 @@
+<?php 
+
+$result = $data['curated_result'] ?? [];
+
+?>
+
+<?php foreach ($result['fields'] as $field) : ?>
+  
+  <?= apply_filters('sitka/render', 'curated-result-field-templates/curated-result-field-template-'.$field['type'].'.php', array_merge($data, [
+		'curated_result_field' => $field,
+	])) ?>
+  
+<?php endforeach; ?>

--- a/views/frontend/curated-result.php
+++ b/views/frontend/curated-result.php
@@ -1,0 +1,10 @@
+<?php
+
+$result = $data['curated_result'] ?? [];
+
+?>
+<div class="sitka-search-card curated-result">
+	<?= apply_filters('sitka/render', 'curated-result-templates/curated-result-template-'.$result['template'].'.php', array_merge($data, [
+		'curated_result' => $result,
+	])) ?>
+</div>

--- a/views/frontend/curated-result.php
+++ b/views/frontend/curated-result.php
@@ -3,7 +3,7 @@
 $result = $data['curated_result'] ?? [];
 
 ?>
-<div class="sitka-search-card curated-result">
+<div class="sitka-curated-result">
 	<?= apply_filters('sitka/render', 'curated-result-templates/curated-result-template-'.$result['template'].'.php', array_merge($data, [
 		'curated_result' => $result,
 	])) ?>

--- a/views/frontend/search-results.php
+++ b/views/frontend/search-results.php
@@ -11,7 +11,7 @@ $originalQuery = $response['originalQueryPhrase'] ?? '';
 $supersedingSuggestion = $response['supersedingSuggestion'] ?? '';
 $didYouMeanOption = get_option('sitka_search_instead_enabled') ?? 'disabled';
 $curatedResultsOption = get_option('sitka_search_curated_results_enabled') ?? 'disabled';
-$curatedResultsEnables = $response['curatedResultsEnabled'] ?? false;
+$curatedResultsEnabled = $response['curatedResultsEnabled'] ?? false;
 
 ?>
 <section class="sitka-search-form-container">
@@ -41,7 +41,7 @@ $curatedResultsEnables = $response['curatedResultsEnabled'] ?? false;
   </div><!-- container -->
 </section>
 
-<?php if ($curatedResultsOption == "enabled" && $curatedResultsEnables && isset($response['curatedResults']) && !empty($response['curatedResults'])) { ?>
+<?php if ($curatedResultsOption == "enabled" && $curatedResultsEnabled && isset($response['curatedResults']) && !empty($response['curatedResults'])) { ?>
   <section class="sitka-search-results-container curated-results">
   
     <h2 class="sitka-curated-results-section-headline"> Recommended results</h2>

--- a/views/frontend/search-results.php
+++ b/views/frontend/search-results.php
@@ -10,6 +10,8 @@ $searchQuery = stripslashes($data['query']) ?? '';
 $originalQuery = $response['originalQueryPhrase'] ?? '';
 $supersedingSuggestion = $response['supersedingSuggestion'] ?? '';
 $didYouMeanOption = get_option('sitka_search_instead_enabled') ?? 'disabled';
+$curatedResultsOption = get_option('sitka_search_curated_results_enabled') ?? 'disabled';
+$curatedResultsEnables = $response['curatedResultsEnabled'] ?? false;
 
 ?>
 <section class="sitka-search-form-container">
@@ -25,7 +27,7 @@ $didYouMeanOption = get_option('sitka_search_instead_enabled') ?? 'disabled';
           placeholder="Enter keyword or phrase"
           title="Enter keyword or phrase"
         />
-        <?php if ($response['suggestionSupersededQuery']  && $didYouMeanOption == "enabled") : ?>
+        <?php if (isset($response['suggestionSupersededQuery']) && $response['suggestionSupersededQuery']  && $didYouMeanOption == "enabled") : ?>
           <div class="superseding-suggestion-container">
             <p>
               Showing results for <?= $supersedingSuggestion ?> </br> 
@@ -38,12 +40,31 @@ $didYouMeanOption = get_option('sitka_search_instead_enabled') ?? 'disabled';
     </div><!-- global-search -->
   </div><!-- container -->
 </section>
+
+<?php if ($curatedResultsOption == "enabled" && $curatedResultsEnables && isset($response['curatedResults']) && !empty($response['curatedResults'])) { ?>
+  <section class="sitka-search-results-container curated-results">
+    <div class="container">
+      <h2> Curated results</h2>
+      <?php if (!empty($response['curatedResults'])) : ?>
+        <?php foreach ($response['curatedResults'] as $result) : ?>
+
+          <?= apply_filters('sitka/render', 'curated-result.php', array_merge($data, [
+            'curated_result' => $result,
+          ])) ?>
+
+        <?php endforeach; ?>
+      <?php endif; ?>
+
+    </div>
+  </section>
+<?php } ?>
+
 <section class="sitka-search-results-container">
   <div class="container">
 
     <?php if (!empty($response['results'])) : ?>
       <?php foreach ($response['results'] as $result) : ?>
-
+      
         <?= apply_filters('sitka/render', 'search-result.php', array_merge($data, [
           'result' => $result,
         ])) ?>

--- a/views/frontend/search-results.php
+++ b/views/frontend/search-results.php
@@ -43,19 +43,18 @@ $curatedResultsEnables = $response['curatedResultsEnabled'] ?? false;
 
 <?php if ($curatedResultsOption == "enabled" && $curatedResultsEnables && isset($response['curatedResults']) && !empty($response['curatedResults'])) { ?>
   <section class="sitka-search-results-container curated-results">
-    <div class="container">
-      <h2> Curated results</h2>
-      <?php if (!empty($response['curatedResults'])) : ?>
-        <?php foreach ($response['curatedResults'] as $result) : ?>
+  
+    <h2 class="sitka-curated-results-section-headline"> Recommended results</h2>
+    <?php if (!empty($response['curatedResults'])) : ?>
+      <?php foreach ($response['curatedResults'] as $result) : ?>
 
-          <?= apply_filters('sitka/render', 'curated-result.php', array_merge($data, [
-            'curated_result' => $result,
-          ])) ?>
+        <?= apply_filters('sitka/render', 'curated-result.php', array_merge($data, [
+          'curated_result' => $result,
+        ])) ?>
 
-        <?php endforeach; ?>
-      <?php endif; ?>
+      <?php endforeach; ?>
+    <?php endif; ?>
 
-    </div>
   </section>
 <?php } ?>
 

--- a/views/settings-meta.php
+++ b/views/settings-meta.php
@@ -40,10 +40,13 @@
         <input type="radio" id="env-prd" name="sitka_environment" value="production" <?= $data['sitka_environment'] === 'production' ? 'checked' : '' ?>>
         <label for="env-prd">Production</label>
       </div>
-      <div class="sitka-field__env-option">
-        <input type="radio" id="env-stg" name="sitka_environment" value="staging" <?= $data['sitka_environment'] === 'staging' ? 'checked' : '' ?>>
-        <label for="env-stg">Staging</label>
-      </div>
+      <?php 
+      // Option removed per request from Phil Price
+      //  <div class="sitka-field__env-option">
+      //   <input type="radio" id="env-stg" name="sitka_environment" value="staging" <?= $data['sitka_environment'] === 'staging' ? 'checked' : '' ?>>
+      //   <label for="env-stg">Staging</label>
+      // </div> 
+      ?>
     </div>
   </div>
 
@@ -57,13 +60,29 @@
         <label for="sitka_search_instead_enabled">Enable</label>
       </div>
       <div class="sitka-field__dym-option">
-        <input type="radio" id="sitka_search_instead_enabled" name="sitka_search_instead_enabled" value="disabled"<?= $data['sitka_search_instead_enabled'] !== 'enabled' ? 'checked' : '' ?>>
-        <label for="sitka_search_instead_enabled">Disable</label>
+        <input type="radio" id="sitka_search_instead_disabled" name="sitka_search_instead_enabled" value="disabled"<?= $data['sitka_search_instead_enabled'] !== 'enabled' ? 'checked' : '' ?>>
+        <label for="sitka_search_instead_disabled">Disable</label>
       </div>
         <p>When enabled, Sitka will present a link to override automatic typo correction.</p>
     </div>
   </div>
 
+  <div class="sitka-field sitka-field--flex">
+    <div class="sitka-field__label">
+      <label><b>Include Curated Results on the search page</b></label>
+    </div>
+    <div class="sitka-field__input">
+      <div class="sitka-field__dym-option">
+        <input type="radio" id="sitka_search_curated_results_enabled" name="sitka_search_curated_results_enabled" value="enabled"<?= $data['sitka_search_curated_results_enabled'] === 'enabled' ? 'checked' : '' ?>>
+        <label for="sitka_search_curated_results_enabled">Enable</label>
+      </div>
+      <div class="sitka-field__dym-option">
+        <input type="radio" id="sitka_search_curated_results_disabled" name="sitka_search_curated_results_enabled" value="disabled"<?= $data['sitka_search_curated_results_enabled'] !== 'enabled' ? 'checked' : '' ?>>
+        <label for="sitka_search_curated_results_disabled">Disable</label>
+      </div>
+        <p>When enabled, curated result will appear in search results. Please note: This feature must first be enabled in the Sitka Dashboard.</p>
+    </div>
+  </div>
   <h3>Add Shortcode To Page</h3>
   <div class="sitka-field">
     <p>Please insert this shortcode on the page where you would like search results to appear.</p>

--- a/views/settings-meta.php
+++ b/views/settings-meta.php
@@ -41,11 +41,12 @@
         <label for="env-prd">Production</label>
       </div>
       <?php 
-      // Option removed per request from Phil Price
-      //  <div class="sitka-field__env-option">
-      //   <input type="radio" id="env-stg" name="sitka_environment" value="staging" <?= $data['sitka_environment'] === 'staging' ? 'checked' : '' ?>>
-      //   <label for="env-stg">Staging</label>
-      // </div> 
+      /* Option removed per request from Phil Price
+      <div class="sitka-field__env-option">
+         <input type="radio" id="env-stg" name="sitka_environment" value="staging" <?= $data['sitka_environment'] === 'staging' ? 'checked' : '' ?>>
+         <label for="env-stg">Staging</label>
+      </div>
+      */ 
       ?>
     </div>
   </div>

--- a/views/settings-meta.php
+++ b/views/settings-meta.php
@@ -42,6 +42,8 @@
       </div>
       <?php 
       /* Option removed per request from Phil Price
+      * If a developer needs to test someting against the staging instance of the Sitka, simply remove the comments around this block of code to begin the staging option back in. 
+      * This should be temporary change will be reverted when the plugin is reinstalled using composer.
       <div class="sitka-field__env-option">
          <input type="radio" id="env-stg" name="sitka_environment" value="staging" <?= $data['sitka_environment'] === 'staging' ? 'checked' : '' ?>>
          <label for="env-stg">Staging</label>


### PR DESCRIPTION
Added curated results functionality to the plugin. 

- Switched `gearlab-tools-php` dependency to use `curated-search` branch (to get the curated result capability available on the SDK level).
- Added templates to handle `quick_links` template 
- Added set of field templates to cover available curated result field types out of the box
- Added enable/disable toggle to the plugin settings
- Implemented basic style for curated results section

Contact @akoziolsc for details on testing setup of the plugin.
