### PR TITLE
Update/composer versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.tar.gz
 *.zip
 .phpunit.result.cache
+/releases/
 
 # editor artifacts
 *.swp

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ wp option set sitka_enabled 1
 
 To build a new release use the script `./bin/create-release.sh`
 
-Make sure all your changes are committed then run: 
+Make sure all your changes are committed then run this script and follow the prompts: 
 
 ```sh
 ./bin/create-release.sh
@@ -337,3 +337,13 @@ This script will:
 * Create a tag with the version number
 * Create `.zip` and `.tar.gz` archives. 
 * Create a GitHub release and upload the built assets
+
+### Prerequisites
+
+The script requires the following tools to be installed:
+
+- **git** - Version control
+- **gh** (GitHub CLI) - For creating releases. Install from https://cli.github.com/
+- **jq** - JSON processor for updating composer.json
+- **zip** - For creating . zip archives
+- **tar** - For creating .tar.gz archives

--- a/README.md
+++ b/README.md
@@ -319,12 +319,21 @@ wp option set sitka_enabled 1
 
 ## Development
 
-To build a new release, choose the Git tag name and run:
+To build a new release use the script `./bin/create-release.sh`
 
-```bash
-bin/build-release.sh <TAG>
+Make sure all your changes are committed then run: 
+
+```sh
+./bin/create-release.sh
 ```
 
-This will create a .tar.gz and a .zip archive which you can upload to a new release on GitHub.
+This script will: 
 
-If you have [`hub`](https://hub.github.com/) installed, the script will detect it and prompt you to optionally create a GitHub release directly.
+* Request a new version number
+* Update the version in the `sitka-insights.php` file
+* Update the `composer.json` file:
+  * Change the `version` value
+  * Update the `dist.url` value to match the download URL from the release
+* Create a tag with the version number
+* Create `.zip` and `.tar.gz` archives. 
+* Create a GitHub release and upload the built assets

--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -126,10 +126,10 @@ function restore_vendor() {
 
 function create_github_release() {
   if [[ $(which hub) ]] ; then
-    echo $($BOLD)hub detected! You win at Git!$($RESET)
-    read -p 'Create a GitHub release? (y/N) ' create
+    echo "$($BOLD)hub detected! You win at Git!$($RESET)"
+    read -r -p 'Create a GitHub release? (y/N) ' create
     if [[ "$create" = "y" ]] ; then
-      read -p 'Is this a pre-release? (y/N) ' prerelease
+      read -r -p 'Is this a pre-release? (y/N) ' prerelease
       if [[ "$prerelease" = "y" ]] ; then
         prerelease_opt='--prerelease'
       fi
@@ -137,7 +137,7 @@ function create_github_release() {
       echo 'pushing latest changes and tags...'
       git push origin main
       git push --tags
-      hub release create $prerelease_opt -a "$2" -a "$3" -e "$1"
+      hub release create "$prerelease_opt" -a "$2" -a "$3" -e "$1"
     else
       echo 'skipping GitHub release.'
     fi

--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -18,11 +18,16 @@ function fail() {
   echo $($RED; $BOLD)
   echo "$1"
   echo $($RESET)
-  usage
+  # usage
   exit 1
 }
 
 function main() {
+
+
+  fail 'This script has been replaced with bin/create-release.sh. Check the readme for usage instructions. Please use that script instead.'
+
+
   if ! [[ -f ./sitka-insights.php ]] ; then
     fail 'Error: not in root sitka-insights-wordpress directory?'
   fi

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exit on error
 set -e

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -106,27 +106,53 @@ success "Pushed to remote"
 
 # Create releases directory if it doesn't exist
 mkdir -p releases
+ln -sfn . sitka-insights
 
 # Create ZIP archive
 info "Creating ZIP archive..."
-ZIP_FILE="releases/sitka-insights-$VERSION"
-composer archive --format=zip --file="$ZIP_FILE"
+ZIP_FILE="releases/sitka-insights-$VERSION.zip"
+zip -r "$ZIP_FILE" \
+    sitka-insights/sitka-insights.php \
+    sitka-insights/wp-api.php \
+    sitka-insights/src \
+    sitka-insights/cli \
+    sitka-insights/js \
+    sitka-insights/css \
+    sitka-insights/vendor \
+    sitka-insights/views \
+    sitka-insights/LICENSE.txt \
+    sitka-insights/README.md
+
 success "Created $ZIP_FILE"
 
 # Create TAR.GZ archive
 info "Creating TAR.GZ archive..."
-TAR_FILE="releases/sitka-insights-$VERSION"
-composer archive --format=tar.gz --file="$TAR_FILE"
+TAR_FILE="releases/sitka-insights-$VERSION.tar.gz"
+tar -cvzf "$TAR_FILE" \
+    sitka-insights/vendor/autoload.php \
+    sitka-insights/sitka-insights.php \
+    sitka-insights/wp-api.php \
+    sitka-insights/src \
+    sitka-insights/cli \
+    sitka-insights/js \
+    sitka-insights/css \
+    sitka-insights/vendor \
+    sitka-insights/views \
+    sitka-insights/LICENSE.txt \
+    sitka-insights/README.md
 
 success "Created $TAR_FILE"
+
+# Remove hackish symlink
+rm ./sitka-insights
 
 # Create GitHub release
 info "Creating GitHub release..."
 gh release create "v$VERSION" \
     --title "Version v$VERSION" \
     --generate-notes \
-    "$REPO_ROOT/$ZIP_FILE.zip" \
-    "$REPO_ROOT/$TAR_FILE.tar.gz"
+    "$REPO_ROOT/$ZIP_FILE" \
+    "$REPO_ROOT/$TAR_FILE"
 
 success "GitHub release created successfully!"
 

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -78,12 +78,12 @@ success "Updated sitka-insights.php"
 
 # Update version and dist.url in composer.json
 info "Updating composer.json..."
-DIST_URL="https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/$VERSION/sitka-insights-$VERSION.zip"
+DIST_URL="https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/v$VERSION/sitka-insights-$VERSION.zip"
 
 # Use jq to update composer.json
 jq --arg version "$VERSION" \
    --arg url "$DIST_URL" \
-   '. version = $version | .dist.url = $url' \
+   '.version = $version | .dist.url = $url' \
    composer.json > composer.json.tmp && mv composer.json.tmp composer.json
 
 success "Updated composer.json"
@@ -109,13 +109,13 @@ mkdir -p releases
 
 # Create ZIP archive
 info "Creating ZIP archive..."
-ZIP_FILE="releases/sitka-insights-$VERSION.zip"
+ZIP_FILE="releases/sitka-insights-$VERSION"
 composer archive --format=zip --file="$ZIP_FILE"
 success "Created $ZIP_FILE"
 
 # Create TAR.GZ archive
 info "Creating TAR.GZ archive..."
-TAR_FILE="releases/sitka-insights-$VERSION.tar.gz"
+TAR_FILE="releases/sitka-insights-$VERSION"
 composer archive --format=tar.gz --file="$TAR_FILE"
 
 success "Created $TAR_FILE"
@@ -123,10 +123,10 @@ success "Created $TAR_FILE"
 # Create GitHub release
 info "Creating GitHub release..."
 gh release create "v$VERSION" \
-    --title "Version $VERSION" \
+    --title "Version v$VERSION" \
     --generate-notes \
-    "$ZIP_FILE" \
-    "$TAR_FILE"
+    "$REPO_ROOT/$ZIP_FILE.zip" \
+    "$REPO_ROOT/$TAR_FILE.tar.gz"
 
 success "GitHub release created successfully!"
 

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -37,9 +37,9 @@ if !  git rev-parse --git-dir > /dev/null 2>&1; then
 fi
 
 # Check if working directory is clean
-if ! git diff-index --quiet HEAD --; then
-    error "Working directory is not clean.  Please commit or stash your changes first."
-fi
+# if ! git diff-index --quiet HEAD --; then
+#     error "Working directory is not clean.  Please commit or stash your changes first."
+# fi
 
 # Get repository info
 REPO_ROOT=$(git rev-parse --show-toplevel)
@@ -55,10 +55,10 @@ info "Current version information:"
 grep -E "Version:|\"version\":" sitka-insights.php composer.json 2>/dev/null || true
 echo ""
 
-read -pr "Enter new version number (e.g., 1.2.3): " VERSION
+read -p "Enter new version number (e.g., 1.2.3): " VERSION
 
 # Validate version format (basic semver check)
-if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+[a-z]?$ ]]; then
     error "Invalid version format. Please use semantic versioning (e.g., 1.2.3)"
 fi
 
@@ -73,8 +73,7 @@ fi
 
 # Update version in sitka-insights.php
 info "Updating version in sitka-insights.php..."
-sed -i. bak -E "s/(Version:[[: space:]]*)[0-9]+\.[0-9]+\.[0-9]+/\1$VERSION/" sitka-insights.php
-rm -f sitka-insights.php. bak
+sed -i -E "s/(^\s*\* Version:)\s*[^\r\n]*/\1 $VERSION/" sitka-insights.php
 success "Updated sitka-insights.php"
 
 # Update version and dist.url in composer.json

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -146,11 +146,22 @@ success "Created $TAR_FILE"
 # Remove hackish symlink
 rm ./sitka-insights
 
+# Ask if this is a pre-release
+read -p "Is this a pre-release? (y/N): " -n 1 -r
+echo
+PRERELEASE_FLAG=""
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    PRERELEASE_FLAG="--prerelease"
+    info "This will be marked as a pre-release"
+fi
+
+
 # Create GitHub release
 info "Creating GitHub release..."
 gh release create "v$VERSION" \
     --title "Version v$VERSION" \
     --generate-notes \
+    $PRERELEASE_FLAG \
     "$REPO_ROOT/$ZIP_FILE" \
     "$REPO_ROOT/$TAR_FILE"
 

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -58,7 +58,8 @@ echo ""
 read -p "Enter new version number (e.g., 1.2.3): " VERSION
 
 # Validate version format (basic semver check)
-if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+[a-z]?$ ]]; then
+if ! [[ "$VERSION" =~ ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+ ]]; then
     error "Invalid version format. Please use semantic versioning (e.g., 1.2.3)"
 fi
 

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -37,9 +37,9 @@ if !  git rev-parse --git-dir > /dev/null 2>&1; then
 fi
 
 # Check if working directory is clean
-# if ! git diff-index --quiet HEAD --; then
-#     error "Working directory is not clean.  Please commit or stash your changes first."
-# fi
+if ! git diff-index --quiet HEAD --; then
+    error "Working directory is not clean.  Please commit or stash your changes first."
+fi
 
 # Get repository info
 REPO_ROOT=$(git rev-parse --show-toplevel)

--- a/bin/create-release.sh
+++ b/bin/create-release.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored messages
+error() {
+    echo -e "${RED}ERROR: $1${NC}" >&2
+    exit 1
+}
+
+success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+info() {
+    echo -e "${YELLOW}→ $1${NC}"
+}
+
+# Check if required commands exist
+command -v git >/dev/null 2>&1 || error "git is required but not installed"
+command -v gh >/dev/null 2>&1 || error "GitHub CLI (gh) is required but not installed.  Install from https://cli.github.com/"
+command -v jq >/dev/null 2>&1 || error "jq is required but not installed"
+command -v zip >/dev/null 2>&1 || error "zip is required but not installed"
+command -v tar >/dev/null 2>&1 || error "tar is required but not installed"
+command -v composer >/dev/null 2>&1 || error "composer is required but not installed"
+
+# Check if we're in a git repository
+if !  git rev-parse --git-dir > /dev/null 2>&1; then
+    error "Not in a git repository"
+fi
+
+# Check if working directory is clean
+if ! git diff-index --quiet HEAD --; then
+    error "Working directory is not clean.  Please commit or stash your changes first."
+fi
+
+# Get repository info
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+# Check if required files exist
+[[ -f "sitka-insights.php" ]] || error "sitka-insights.php not found"
+[[ -f "composer.json" ]] || error "composer. json not found"
+
+# Request new version number
+echo ""
+info "Current version information:"
+grep -E "Version:|\"version\":" sitka-insights.php composer.json 2>/dev/null || true
+echo ""
+
+read -pr "Enter new version number (e.g., 1.2.3): " VERSION
+
+# Validate version format (basic semver check)
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    error "Invalid version format. Please use semantic versioning (e.g., 1.2.3)"
+fi
+
+info "Preparing release for version $VERSION"
+
+# Confirm with user
+read -p "Are you sure you want to create release $VERSION? (y/N): " -n 1 -r
+echo
+if [[ !  $REPLY =~ ^[Yy]$ ]]; then
+    error "Release cancelled by user"
+fi
+
+# Update version in sitka-insights.php
+info "Updating version in sitka-insights.php..."
+sed -i. bak -E "s/(Version:[[: space:]]*)[0-9]+\.[0-9]+\.[0-9]+/\1$VERSION/" sitka-insights.php
+rm -f sitka-insights.php. bak
+success "Updated sitka-insights.php"
+
+# Update version and dist.url in composer.json
+info "Updating composer.json..."
+DIST_URL="https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/$VERSION/sitka-insights-$VERSION.zip"
+
+# Use jq to update composer.json
+jq --arg version "$VERSION" \
+   --arg url "$DIST_URL" \
+   '. version = $version | .dist.url = $url' \
+   composer.json > composer.json.tmp && mv composer.json.tmp composer.json
+
+success "Updated composer.json"
+
+# Commit changes
+info "Committing changes..."
+git add sitka-insights.php composer.json
+git commit -m "Bump version to $VERSION"
+success "Changes committed"
+
+# Create and push tag
+info "Creating git tag v$VERSION..."
+git tag -a "v$VERSION" -m "Release version $VERSION"
+success "Tag created"
+
+info "Pushing changes and tag to remote..."
+git push origin HEAD
+git push origin "v$VERSION"
+success "Pushed to remote"
+
+# Create releases directory if it doesn't exist
+mkdir -p releases
+
+# Create ZIP archive
+info "Creating ZIP archive..."
+ZIP_FILE="releases/sitka-insights-$VERSION.zip"
+composer archive --format=zip --file="$ZIP_FILE"
+success "Created $ZIP_FILE"
+
+# Create TAR.GZ archive
+info "Creating TAR.GZ archive..."
+TAR_FILE="releases/sitka-insights-$VERSION.tar.gz"
+composer archive --format=tar.gz --file="$TAR_FILE"
+
+success "Created $TAR_FILE"
+
+# Create GitHub release
+info "Creating GitHub release..."
+gh release create "v$VERSION" \
+    --title "Version $VERSION" \
+    --generate-notes \
+    "$ZIP_FILE" \
+    "$TAR_FILE"
+
+success "GitHub release created successfully!"
+
+echo ""
+echo -e "${GREEN}════════════════════════════════════════════════════${NC}"
+echo -e "${GREEN}Release $VERSION completed successfully!${NC}"
+echo -e "${GREEN}════════════════════════════════════════════════════${NC}"
+echo ""
+info "Archives created:"
+echo "  - $ZIP_FILE"
+echo "  - $TAR_FILE"
+echo ""
+info "Next steps:"
+echo "  - Review the release at:  https://github.com/sitecrafting/sitka-insights-wordpress/releases/tag/v$VERSION"
+echo "  - Update any documentation if needed"
+echo ""

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "composer/installers": "~1.0",
     "sitecrafting/gearlab-tools-php": "^3.0"
   },
-  "version": "0.0.16b",
+  "version": "0.0.17b",
   "dist": {
     "type": "zip",
-    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/v0.0.16b/sitka-insights-0.0.16b.zip"
+    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/v0.0.17b/sitka-insights-0.0.17b.zip"
   },
   "archive": {
     "exclude": [

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "composer/installers": "~1.0",
     "sitecrafting/gearlab-tools-php": "^3.0"
   },
-  "version": "0.0.14b",
+  "version": "0.0.15b",
   "dist": {
     "type": "zip",
-    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/0.0.14b/sitka-insights-0.0.14b.zip"
+    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/v0.0.15b/sitka-insights-0.0.15b.zip"
   },
   "archive": {
     "exclude": [

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "composer/installers": "~1.0",
     "sitecrafting/gearlab-tools-php": "^3.0"
   },
-  "version": "v0.0.0.6b",
+  "version": "0.0.7b",
   "dist": {
     "type": "zip",
-    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/v0.0.0.6b/sitka-insights-v0.0.0.6b.zip"
+    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/0.0.7b/sitka-insights-0.0.7b.zip"
   },
   "archive": {
     "exclude": [

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "composer/installers": "~1.0",
     "sitecrafting/gearlab-tools-php": "^3.0"
   },
-  "version": "0.0.15b",
+  "version": "0.0.16b",
   "dist": {
     "type": "zip",
-    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/v0.0.15b/sitka-insights-0.0.15b.zip"
+    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/v0.0.16b/sitka-insights-0.0.16b.zip"
   },
   "archive": {
     "exclude": [

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
   "archive": {
     "exclude": [
       "/test/",
+      "/releases/"
       ".gitignore",
       "bin/",
       "/.github/"

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "composer/installers": "~1.0",
     "sitecrafting/gearlab-tools-php": "^3.0"
   },
-  "version": "0.0.9b",
+  "version": "0.0.10b",
   "dist": {
     "type": "zip",
-    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/0.0.9b/sitka-insights-0.0.9b.zip"
+    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/0.0.10b/sitka-insights-0.0.10b.zip"
   },
   "archive": {
     "exclude": [

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,11 @@
     "composer/installers": "~1.0",
     "sitecrafting/gearlab-tools-php": "^3.0"
   },
+  "version": "0.0.0.3b",
+  "dist": {
+    "type": "zip",
+    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/v0.0.0.0.3b/sitka-insights-v0.0.0.3b.zip"
+  },
   "archive": {
     "exclude": [
       "/test/",

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "composer/installers": "~1.0",
     "sitecrafting/gearlab-tools-php": "^3.0"
   },
-  "version": "0.0.0.4b",
+  "version": "0.0.0.5b",
   "dist": {
     "type": "zip",
-    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/v0.0.0.4b/sitka-insights-v0.0.0.4b.zip"
+    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/v0.0.0.5b/sitka-insights-v0.0.0.5b.zip"
   },
   "archive": {
     "exclude": [

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "composer/installers": "~1.0",
     "sitecrafting/gearlab-tools-php": "^3.0"
   },
-  "version": "0.0.11b",
+  "version": "0.0.12b",
   "dist": {
     "type": "zip",
-    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/0.0.11b/sitka-insights-0.0.11b.zip"
+    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/0.0.12b/sitka-insights-0.0.12b.zip"
   },
   "archive": {
     "exclude": [

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,14 @@
     "composer/installers": "~1.0",
     "sitecrafting/gearlab-tools-php": "^3.0"
   },
+  "archive": {
+    "exclude": [
+      "/test/",
+      ".gitignore",
+      "bin/",
+      "/.github/"
+    ]
+  },
   "license": "MIT",
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -7,15 +7,15 @@
     "composer/installers": "~1.0",
     "sitecrafting/gearlab-tools-php": "^3.0"
   },
-  "version": "0.0.12b",
+  "version": "0.0.14b",
   "dist": {
     "type": "zip",
-    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/0.0.12b/sitka-insights-0.0.12b.zip"
+    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/0.0.14b/sitka-insights-0.0.14b.zip"
   },
   "archive": {
     "exclude": [
       "/test/",
-      "/releases/"
+      "/releases/",
       ".gitignore",
       "bin/",
       "/.github/"

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "composer/installers": "~1.0",
     "sitecrafting/gearlab-tools-php": "^3.0"
   },
-  "version": "0.0.10b",
+  "version": "0.0.11b",
   "dist": {
     "type": "zip",
-    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/0.0.10b/sitka-insights-0.0.10b.zip"
+    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/0.0.11b/sitka-insights-0.0.11b.zip"
   },
   "archive": {
     "exclude": [

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "composer/installers": "~1.0",
     "sitecrafting/gearlab-tools-php": "^3.0"
   },
-  "version": "0.0.0.5b",
+  "version": "v0.0.0.6b",
   "dist": {
     "type": "zip",
-    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/v0.0.0.5b/sitka-insights-v0.0.0.5b.zip"
+    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/v0.0.0.6b/sitka-insights-v0.0.0.6b.zip"
   },
   "archive": {
     "exclude": [

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "composer/installers": "~1.0",
     "sitecrafting/gearlab-tools-php": "^3.0"
   },
-  "version": "0.0.8b",
+  "version": "0.0.9b",
   "dist": {
     "type": "zip",
-    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/0.0.8b/sitka-insights-0.0.8b.zip"
+    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/0.0.9b/sitka-insights-0.0.9b.zip"
   },
   "archive": {
     "exclude": [

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "composer/installers": "~1.0",
     "sitecrafting/gearlab-tools-php": "^3.0"
   },
-  "version": "0.0.7b",
+  "version": "0.0.8b",
   "dist": {
     "type": "zip",
-    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/0.0.7b/sitka-insights-0.0.7b.zip"
+    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/0.0.8b/sitka-insights-0.0.8b.zip"
   },
   "archive": {
     "exclude": [

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
     "composer/installers": "~1.0",
     "sitecrafting/gearlab-tools-php": "^3.0"
   },
-  "version": "0.0.0.3b",
+  "version": "0.0.0.4b",
   "dist": {
     "type": "zip",
-    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/v0.0.0.0.3b/sitka-insights-v0.0.0.3b.zip"
+    "url": "https://github.com/sitecrafting/sitka-insights-wordpress/releases/download/v0.0.0.4b/sitka-insights-v0.0.0.4b.zip"
   },
   "archive": {
     "exclude": [

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -6,7 +6,7 @@
  * Plugin URI: https://www.sitkainsights.com
  * Author: SiteCrafting, Inc. <hello@sitecrafting.com>
  * Author URI: https://www.sitecrafting.com/
- * Version: 0.0.7b
+ * Version: 0.0.8b
  * Requires PHP: 7.1
  */
 

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -6,7 +6,7 @@
  * Plugin URI: https://www.sitkainsights.com
  * Author: SiteCrafting, Inc. <hello@sitecrafting.com>
  * Author URI: https://www.sitecrafting.com/
- * Version: 0.0.10b
+ * Version: 0.0.11b
  * Requires PHP: 7.1
  */
 

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -6,7 +6,7 @@
  * Plugin URI: https://www.sitkainsights.com
  * Author: SiteCrafting, Inc. <hello@sitecrafting.com>
  * Author URI: https://www.sitecrafting.com/
- * Version: 0.0.16b
+ * Version: 0.0.17b
  * Requires PHP: 7.1
  */
 

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -6,7 +6,7 @@
  * Plugin URI: https://www.sitkainsights.com
  * Author: SiteCrafting, Inc. <hello@sitecrafting.com>
  * Author URI: https://www.sitecrafting.com/
- * Version: 0.0.9b
+ * Version: 0.0.10b
  * Requires PHP: 7.1
  */
 

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -6,7 +6,7 @@
  * Plugin URI: https://www.sitkainsights.com
  * Author: SiteCrafting, Inc. <hello@sitecrafting.com>
  * Author URI: https://www.sitecrafting.com/
- * Version: 3.0.1
+ * Version: 0.0.7b
  * Requires PHP: 7.1
  */
 

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -6,7 +6,7 @@
  * Plugin URI: https://www.sitkainsights.com
  * Author: SiteCrafting, Inc. <hello@sitecrafting.com>
  * Author URI: https://www.sitecrafting.com/
- * Version: 0.0.13b
+ * Version: 0.0.14b
  * Requires PHP: 7.1
  */
 

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -6,7 +6,7 @@
  * Plugin URI: https://www.sitkainsights.com
  * Author: SiteCrafting, Inc. <hello@sitecrafting.com>
  * Author URI: https://www.sitecrafting.com/
- * Version: 0.0.12b
+ * Version: 0.0.13b
  * Requires PHP: 7.1
  */
 

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -6,7 +6,7 @@
  * Plugin URI: https://www.sitkainsights.com
  * Author: SiteCrafting, Inc. <hello@sitecrafting.com>
  * Author URI: https://www.sitecrafting.com/
- * Version: 0.0.15b
+ * Version: 0.0.16b
  * Requires PHP: 7.1
  */
 

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -6,7 +6,7 @@
  * Plugin URI: https://www.sitkainsights.com
  * Author: SiteCrafting, Inc. <hello@sitecrafting.com>
  * Author URI: https://www.sitecrafting.com/
- * Version: 0.0.14b
+ * Version: 0.0.15b
  * Requires PHP: 7.1
  */
 

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -6,7 +6,7 @@
  * Plugin URI: https://www.sitkainsights.com
  * Author: SiteCrafting, Inc. <hello@sitecrafting.com>
  * Author URI: https://www.sitecrafting.com/
- * Version: 0.0.8b
+ * Version: 0.0.9b
  * Requires PHP: 7.1
  */
 

--- a/sitka-insights.php
+++ b/sitka-insights.php
@@ -6,7 +6,7 @@
  * Plugin URI: https://www.sitkainsights.com
  * Author: SiteCrafting, Inc. <hello@sitecrafting.com>
  * Author URI: https://www.sitecrafting.com/
- * Version: 0.0.11b
+ * Version: 0.0.12b
  * Requires PHP: 7.1
  */
 


### PR DESCRIPTION
Rebuild of the release process to better match the composer build process. 

A new build script has been written that: 

* Checks that your repo is committed
* Requests the new release name - needs to be semantic versioning `1.2.3a`
* Updates the plugin version in `sitka-insights.php`
* In the `composer.json` file it:
  * Updates the version
  * updates the release dist URL
* Creates a new tag with the version number
* Creates both a `.zip` and `.tar.gz` archive that is saved in `/releases/`
* Creates the release on GitHub and uploads the release files
